### PR TITLE
[DEV] Main 스크롤 UI 구성

### DIFF
--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -38,7 +38,6 @@ linter:
     - omit_local_variable_types
     - prefer_const_constructors
     - prefer_const_declarations
-    - prefer_single_quotes
     - prefer_void_to_null
     - sized_box_for_whitespace
     - sort_child_properties_last

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,6 +1,6 @@
-import 'package:firebase_crashlytics/firebase_crashlytics.dart';
-import 'package:flutter/material.dart';
-import 'package:todo_project/util/firebase_util.dart';
+import "package:flutter/material.dart";
+import "package:todo_project/pages/main/main_page.dart";
+import "package:todo_project/util/firebase_util.dart";
 
 void main() async {
   WidgetsFlutterBinding.ensureInitialized();
@@ -12,119 +12,15 @@ void main() async {
 class MyApp extends StatelessWidget {
   const MyApp({super.key});
 
-  // This widget is the root of your application.
   @override
   Widget build(BuildContext context) {
     return MaterialApp(
-      title: 'Flutter Demo',
+      title: "Flutter Demo",
       theme: ThemeData(
-        // This is the theme of your application.
-        //
-        // TRY THIS: Try running your application with "flutter run". You'll see
-        // the application has a purple toolbar. Then, without quitting the app,
-        // try changing the seedColor in the colorScheme below to Colors.green
-        // and then invoke "hot reload" (save your changes or press the "hot
-        // reload" button in a Flutter-supported IDE, or press "r" if you used
-        // the command line to start the app).
-        //
-        // Notice that the counter didn't reset back to zero; the application
-        // state is not lost during the reload. To reset the state, use hot
-        // restart instead.
-        //
-        // This works for code too, not just values: Most code changes can be
-        // tested with just a hot reload.
         colorScheme: ColorScheme.fromSeed(seedColor: Colors.deepPurple),
         useMaterial3: true,
       ),
-      home: const MyHomePage(title: 'Flutter Demo Home Page'),
-    );
-  }
-}
-
-class MyHomePage extends StatefulWidget {
-  const MyHomePage({super.key, required this.title});
-
-  // This widget is the home page of your application. It is stateful, meaning
-  // that it has a State object (defined below) that contains fields that affect
-  // how it looks.
-
-  // This class is the configuration for the state. It holds the values (in this
-  // case the title) provided by the parent (in this case the App widget) and
-  // used by the build method of the State. Fields in a Widget subclass are
-  // always marked "final".
-
-  final String title;
-
-  @override
-  State<MyHomePage> createState() => _MyHomePageState();
-}
-
-class _MyHomePageState extends State<MyHomePage> {
-  int _counter = 0;
-
-  void _incrementCounter() {
-    setState(() {
-      // This call to setState tells the Flutter framework that something has
-      // changed in this State, which causes it to rerun the build method below
-      // so that the display can reflect the updated values. If we changed
-      // _counter without calling setState(), then the build method would not be
-      // called again, and so nothing would appear to happen.
-      _counter++;
-    });
-  }
-
-  @override
-  Widget build(BuildContext context) {
-    // This method is rerun every time setState is called, for instance as done
-    // by the _incrementCounter method above.
-    //
-    // The Flutter framework has been optimized to make rerunning build methods
-    // fast, so that you can just rebuild anything that needs updating rather
-    // than having to individually change instances of widgets.
-    return Scaffold(
-      appBar: AppBar(
-        // TRY THIS: Try changing the color here to a specific color (to
-        // Colors.amber, perhaps?) and trigger a hot reload to see the AppBar
-        // change color while the other colors stay the same.
-        backgroundColor: Theme.of(context).colorScheme.inversePrimary,
-        // Here we take the value from the MyHomePage object that was created by
-        // the App.build method, and use it to set our appbar title.
-        title: Text(widget.title),
-      ),
-      body: Center(
-        // Center is a layout widget. It takes a single child and positions it
-        // in the middle of the parent.
-        child: Column(
-          // Column is also a layout widget. It takes a list of children and
-          // arranges them vertically. By default, it sizes itself to fit its
-          // children horizontally, and tries to be as tall as its parent.
-          //
-          // Column has various properties to control how it sizes itself and
-          // how it positions its children. Here we use mainAxisAlignment to
-          // center the children vertically; the main axis here is the vertical
-          // axis because Columns are vertical (the cross axis would be
-          // horizontal).
-          //
-          // TRY THIS: Invoke "debug painting" (choose the "Toggle Debug Paint"
-          // action in the IDE, or press "p" in the console), to see the
-          // wireframe for each widget.
-          mainAxisAlignment: MainAxisAlignment.center,
-          children: <Widget>[
-            const Text(
-              'You have pushed the button this many times:',
-            ),
-            Text(
-              '$_counter',
-              style: Theme.of(context).textTheme.headlineMedium,
-            ),
-          ],
-        ),
-      ),
-      floatingActionButton: FloatingActionButton(
-        onPressed: _incrementCounter,
-        tooltip: 'Increment',
-        child: const Icon(Icons.add),
-      ), // This trailing comma makes auto-formatting nicer for build methods.
+      home: const MainPage(title: "Flutter Demo Home Page"),
     );
   }
 }

--- a/lib/pages/main/calendar/calendar_view.dart
+++ b/lib/pages/main/calendar/calendar_view.dart
@@ -1,0 +1,18 @@
+import 'package:flutter/material.dart';
+
+class CalendarView extends StatefulWidget {
+  const CalendarView({super.key});
+
+  @override
+  State<StatefulWidget> createState() => _CalendarViewState();
+}
+
+class _CalendarViewState extends State<CalendarView> {
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      width: MediaQuery.of(context).size.width - 120,
+      color: Colors.blue,
+    );
+  }
+}

--- a/lib/pages/main/calendar/calendar_view.dart
+++ b/lib/pages/main/calendar/calendar_view.dart
@@ -1,7 +1,8 @@
 import 'package:flutter/material.dart';
 
 class CalendarView extends StatefulWidget {
-  const CalendarView({super.key});
+  const CalendarView({super.key, required this.isPageEnabled});
+  final bool isPageEnabled;
 
   @override
   State<StatefulWidget> createState() => _CalendarViewState();
@@ -11,8 +12,9 @@ class _CalendarViewState extends State<CalendarView> {
   @override
   Widget build(BuildContext context) {
     return Container(
+      height: MediaQuery.of(context).size.height,
       width: MediaQuery.of(context).size.width - 120,
-      color: Colors.blue,
+      color: widget.isPageEnabled ? Colors.blue : Colors.white,
     );
   }
 }

--- a/lib/pages/main/main_page.dart
+++ b/lib/pages/main/main_page.dart
@@ -36,7 +36,7 @@ class _MainPageState extends State<MainPage> {
                 onTap: () {
                   if(!isCalendarEnabled) _handleScrollSnap(0);
                 },
-                child: const CalendarView()
+                child: CalendarView(isPageEnabled: isCalendarEnabled)
               ),
               const TimeListview(),
               GestureDetector(

--- a/lib/pages/main/main_page.dart
+++ b/lib/pages/main/main_page.dart
@@ -1,0 +1,75 @@
+import 'package:flutter/material.dart';
+
+class MainPage extends StatefulWidget {
+  const MainPage({super.key, required this.title});
+
+  final String title;
+
+  @override
+  State<MainPage> createState() => _MainPageState();
+}
+
+class _MainPageState extends State<MainPage> {
+  int _counter = 0;
+
+  void _incrementCounter() {
+    setState(() {
+      _counter++;
+    });
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    // This method is rerun every time setState is called, for instance as done
+    // by the _incrementCounter method above.
+    //
+    // The Flutter framework has been optimized to make rerunning build methods
+    // fast, so that you can just rebuild anything that needs updating rather
+    // than having to individually change instances of widgets.
+    return Scaffold(
+      appBar: AppBar(
+        // TRY THIS: Try changing the color here to a specific color (to
+        // Colors.amber, perhaps?) and trigger a hot reload to see the AppBar
+        // change color while the other colors stay the same.
+        backgroundColor: Theme.of(context).colorScheme.inversePrimary,
+        // Here we take the value from the MyHomePage object that was created by
+        // the App.build method, and use it to set our appbar title.
+        title: Text(widget.title),
+      ),
+      body: Center(
+        // Center is a layout widget. It takes a single child and positions it
+        // in the middle of the parent.
+        child: Column(
+          // Column is also a layout widget. It takes a list of children and
+          // arranges them vertically. By default, it sizes itself to fit its
+          // children horizontally, and tries to be as tall as its parent.
+          //
+          // Column has various properties to control how it sizes itself and
+          // how it positions its children. Here we use mainAxisAlignment to
+          // center the children vertically; the main axis here is the vertical
+          // axis because Columns are vertical (the cross axis would be
+          // horizontal).
+          //
+          // TRY THIS: Invoke "debug painting" (choose the "Toggle Debug Paint"
+          // action in the IDE, or press "p" in the console), to see the
+          // wireframe for each widget.
+          mainAxisAlignment: MainAxisAlignment.center,
+          children: <Widget>[
+            const Text(
+              "You have pushed the button this many times:",
+            ),
+            Text(
+              "$_counter",
+              style: Theme.of(context).textTheme.headlineMedium,
+            ),
+          ],
+        ),
+      ),
+      floatingActionButton: FloatingActionButton(
+        onPressed: _incrementCounter,
+        tooltip: "Increment",
+        child: const Icon(Icons.add),
+      ), // This trailing comma makes auto-formatting nicer for build methods.
+    );
+  }
+}

--- a/lib/pages/main/main_page.dart
+++ b/lib/pages/main/main_page.dart
@@ -14,6 +14,7 @@ class MainPage extends StatefulWidget {
 
 class _MainPageState extends State<MainPage> {
   final ScrollController _scrollController = ScrollController();
+  bool isCalendarEnabled = true;
 
   @override
   Widget build(BuildContext context) {
@@ -24,16 +25,26 @@ class _MainPageState extends State<MainPage> {
       ),
       body: Listener(
         onPointerUp: (_) {
-          _handleScrollSnap();
+          _handleScrollSnap(_scrollController.offset);
         },
         child: SingleChildScrollView(
           controller: _scrollController,
           scrollDirection: Axis.horizontal,
-          child: const Row(
+          child: Row(
             children: [
-              CalendarView(),
-              TimeListview(),
-              TodoView()
+              GestureDetector(
+                onTap: () {
+                  if(!isCalendarEnabled) _handleScrollSnap(0);
+                },
+                child: const CalendarView()
+              ),
+              const TimeListview(),
+              GestureDetector(
+                onTap: () {
+                  if(isCalendarEnabled) _handleScrollSnap(_scrollController.position.maxScrollExtent);
+                },
+                child: const TodoView()
+              )
             ],
           ),
         ),
@@ -41,23 +52,27 @@ class _MainPageState extends State<MainPage> {
     );
   }
 
-  void _handleScrollSnap() {
-    var curScrollPosition = _scrollController.offset;
+  void _handleScrollSnap(double curScrollPosition) {
     var maxScrollPosition = _scrollController.position.maxScrollExtent;
     var curScrollRatio = curScrollPosition / maxScrollPosition * 100;
 
-    if(curScrollRatio < 50) {
-      _scrollController.animateTo(
-        0,
-        duration: const Duration(milliseconds: 300),
-        curve: Curves.easeOut,
-      );
-    } else {
-      _scrollController.animateTo(
-        maxScrollPosition,
-        duration: const Duration(milliseconds: 300),
-        curve: Curves.easeOut,
-      );
-    }
+    setState(() {
+      if(curScrollRatio < 50) {
+        isCalendarEnabled = true;
+        _scrollController.animateTo(
+          0,
+          duration: const Duration(milliseconds: 300),
+          curve: Curves.easeOut,
+        );
+      } else {
+        isCalendarEnabled = false;
+        _scrollController.animateTo(
+          maxScrollPosition,
+          duration: const Duration(milliseconds: 300),
+          curve: Curves.easeOut,
+        );
+      }
+    });
+
   }
 }

--- a/lib/pages/main/main_page.dart
+++ b/lib/pages/main/main_page.dart
@@ -22,17 +22,42 @@ class _MainPageState extends State<MainPage> {
         backgroundColor: Theme.of(context).colorScheme.inversePrimary,
         title: Text(widget.title),
       ),
-      body: SingleChildScrollView(
-        controller: _scrollController,
-        scrollDirection: Axis.horizontal,
-        child: const Row(
-          children: [
-            CalendarView(),
-            TimeListview(),
-            TodoView()
-          ],
+      body: Listener(
+        onPointerUp: (_) {
+          _handleScrollSnap();
+        },
+        child: SingleChildScrollView(
+          controller: _scrollController,
+          scrollDirection: Axis.horizontal,
+          child: const Row(
+            children: [
+              CalendarView(),
+              TimeListview(),
+              TodoView()
+            ],
+          ),
         ),
       ),
     );
+  }
+
+  void _handleScrollSnap() {
+    var curScrollPosition = _scrollController.offset;
+    var maxScrollPosition = _scrollController.position.maxScrollExtent;
+    var curScrollRatio = curScrollPosition / maxScrollPosition * 100;
+
+    if(curScrollRatio < 50) {
+      _scrollController.animateTo(
+        0,
+        duration: const Duration(milliseconds: 300),
+        curve: Curves.easeOut,
+      );
+    } else {
+      _scrollController.animateTo(
+        maxScrollPosition,
+        duration: const Duration(milliseconds: 300),
+        curve: Curves.easeOut,
+      );
+    }
   }
 }

--- a/lib/pages/main/main_page.dart
+++ b/lib/pages/main/main_page.dart
@@ -1,4 +1,7 @@
 import 'package:flutter/material.dart';
+import 'package:todo_project/pages/main/calendar/calendar_view.dart';
+import 'package:todo_project/pages/main/time_listview.dart';
+import 'package:todo_project/pages/main/todo/todo_view.dart';
 
 class MainPage extends StatefulWidget {
   const MainPage({super.key, required this.title});
@@ -10,66 +13,26 @@ class MainPage extends StatefulWidget {
 }
 
 class _MainPageState extends State<MainPage> {
-  int _counter = 0;
-
-  void _incrementCounter() {
-    setState(() {
-      _counter++;
-    });
-  }
+  final ScrollController _scrollController = ScrollController();
 
   @override
   Widget build(BuildContext context) {
-    // This method is rerun every time setState is called, for instance as done
-    // by the _incrementCounter method above.
-    //
-    // The Flutter framework has been optimized to make rerunning build methods
-    // fast, so that you can just rebuild anything that needs updating rather
-    // than having to individually change instances of widgets.
     return Scaffold(
       appBar: AppBar(
-        // TRY THIS: Try changing the color here to a specific color (to
-        // Colors.amber, perhaps?) and trigger a hot reload to see the AppBar
-        // change color while the other colors stay the same.
         backgroundColor: Theme.of(context).colorScheme.inversePrimary,
-        // Here we take the value from the MyHomePage object that was created by
-        // the App.build method, and use it to set our appbar title.
         title: Text(widget.title),
       ),
-      body: Center(
-        // Center is a layout widget. It takes a single child and positions it
-        // in the middle of the parent.
-        child: Column(
-          // Column is also a layout widget. It takes a list of children and
-          // arranges them vertically. By default, it sizes itself to fit its
-          // children horizontally, and tries to be as tall as its parent.
-          //
-          // Column has various properties to control how it sizes itself and
-          // how it positions its children. Here we use mainAxisAlignment to
-          // center the children vertically; the main axis here is the vertical
-          // axis because Columns are vertical (the cross axis would be
-          // horizontal).
-          //
-          // TRY THIS: Invoke "debug painting" (choose the "Toggle Debug Paint"
-          // action in the IDE, or press "p" in the console), to see the
-          // wireframe for each widget.
-          mainAxisAlignment: MainAxisAlignment.center,
-          children: <Widget>[
-            const Text(
-              "You have pushed the button this many times:",
-            ),
-            Text(
-              "$_counter",
-              style: Theme.of(context).textTheme.headlineMedium,
-            ),
+      body: SingleChildScrollView(
+        controller: _scrollController,
+        scrollDirection: Axis.horizontal,
+        child: const Row(
+          children: [
+            CalendarView(),
+            TimeListview(),
+            TodoView()
           ],
         ),
       ),
-      floatingActionButton: FloatingActionButton(
-        onPressed: _incrementCounter,
-        tooltip: "Increment",
-        child: const Icon(Icons.add),
-      ), // This trailing comma makes auto-formatting nicer for build methods.
     );
   }
 }

--- a/lib/pages/main/main_page.dart
+++ b/lib/pages/main/main_page.dart
@@ -43,7 +43,7 @@ class _MainPageState extends State<MainPage> {
                 onTap: () {
                   if(isCalendarEnabled) _handleScrollSnap(_scrollController.position.maxScrollExtent);
                 },
-                child: const TodoView()
+                child: TodoView(isPageEnabled: !isCalendarEnabled)
               )
             ],
           ),

--- a/lib/pages/main/time_listview.dart
+++ b/lib/pages/main/time_listview.dart
@@ -1,0 +1,18 @@
+import 'package:flutter/material.dart';
+
+class TimeListview extends StatefulWidget {
+  const TimeListview({super.key});
+
+  @override
+  State<StatefulWidget> createState() => _TimeListviewState();
+}
+
+class _TimeListviewState extends State<TimeListview> {
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      width: 60,
+      color: Colors.grey,
+    );
+  }
+}

--- a/lib/pages/main/todo/todo_view.dart
+++ b/lib/pages/main/todo/todo_view.dart
@@ -1,7 +1,8 @@
 import 'package:flutter/material.dart';
 
 class TodoView extends StatefulWidget {
-  const TodoView({super.key});
+  const TodoView({super.key, required this.isPageEnabled});
+  final bool isPageEnabled;
 
   @override
   State<StatefulWidget> createState() => _TodoViewState();
@@ -11,8 +12,9 @@ class _TodoViewState extends State<TodoView> {
   @override
   Widget build(BuildContext context) {
     return Container(
+      height: MediaQuery.of(context).size.height,
       width: MediaQuery.of(context).size.width - 120,
-      color: Colors.green,
+      color: widget.isPageEnabled ? Colors.green : Colors.white,
     );
   }
 }

--- a/lib/pages/main/todo/todo_view.dart
+++ b/lib/pages/main/todo/todo_view.dart
@@ -1,0 +1,18 @@
+import 'package:flutter/material.dart';
+
+class TodoView extends StatefulWidget {
+  const TodoView({super.key});
+
+  @override
+  State<StatefulWidget> createState() => _TodoViewState();
+}
+
+class _TodoViewState extends State<TodoView> {
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      width: MediaQuery.of(context).size.width - 120,
+      color: Colors.green,
+    );
+  }
+}


### PR DESCRIPTION
## Summary
Main 화면에서 사용되는 Scroll-Snap 기반의 UI를 구성하였습니다.

## Description
- Main 화면의 기반이 될 Scroll-Snap UI를 구성하였습니다.
- Main Page를 분리하고, CalendarView와 TodoView, TimeListView를 각각 구현하였습니다.
- Calendar - TimeList - Todo 순으로 Scroll을 적용하였으며, Calendar 또는 Todo 쪽으로 완전히 스크롤되도록 Snap 타입의 ScrollView를 구현하였습니다.
- Horizontal Scroll 발생 시, 화면의 50% 지점을 기준으로 좌/우 페이지로 스크롤이 끝까지 이동하며, 비활성화된 쪽을 Tap 하는 경우에도 해당 페이지로 스크롤됩니다.
- Main Page에서 `isCalendarEnabled`의 State 변수로 페이지 상태를 관리하며, 해당 State 변수를 CalendarView와 TodoView 각각으로 전달해 각 페이지의 상태를 모니터링할 수 있도록 하였습니다. 예제로 활성화된 경우에만 배경색이 적용되도록 구성해두었습니다.

좌측 스크린샷이 CalendarView, 우측 스크린샷이 TodoView가 각각 활성화된 상태입니다.
<div style="display: flex; flex-direction: row;">
  <img src="https://github.com/user-attachments/assets/b6faeee9-ea1d-4406-9d56-b5a940ea8cd7" width="40%"></img>
  <img src="https://github.com/user-attachments/assets/a77ee1ee-54ba-42d5-98fa-39347f1b7262" width="40%"></img>
</div>