### PR TITLE
[DEV/FIX] Main 스크롤 연동 구현 / NDK 버전 관련 수정

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -28,6 +28,10 @@ android {
         targetSdk = 35
         versionCode = flutter.versionCode
         versionName = flutter.versionName
+
+        android {
+            ndkVersion = "27.0.12077973"
+        }
     }
 
     buildTypes {

--- a/lib/pages/main/calendar/calendar_item.dart
+++ b/lib/pages/main/calendar/calendar_item.dart
@@ -1,0 +1,15 @@
+import 'package:flutter/material.dart';
+
+class CalendarItem extends StatelessWidget {
+  const CalendarItem({super.key, required this.itemColor});
+  final Color itemColor;
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      color: itemColor,
+      height: 20,
+      width: double.maxFinite,
+    );
+  }
+}

--- a/lib/pages/main/calendar/calendar_item.dart
+++ b/lib/pages/main/calendar/calendar_item.dart
@@ -1,8 +1,9 @@
 import 'package:flutter/material.dart';
 
 class CalendarItem extends StatelessWidget {
-  const CalendarItem({super.key, required this.itemColor});
+  const CalendarItem({super.key, required this.itemColor, required this.idx});
   final Color itemColor;
+  final int idx;
 
   @override
   Widget build(BuildContext context) {
@@ -10,6 +11,10 @@ class CalendarItem extends StatelessWidget {
       color: itemColor,
       height: 20,
       width: double.maxFinite,
+      child: Text(
+        idx.toString(),
+          textAlign: TextAlign.end,
+      ),
     );
   }
 }

--- a/lib/pages/main/calendar/calendar_view.dart
+++ b/lib/pages/main/calendar/calendar_view.dart
@@ -2,8 +2,9 @@ import 'package:flutter/material.dart';
 import 'package:todo_project/pages/main/calendar/calendar_item.dart';
 
 class CalendarView extends StatefulWidget {
-  const CalendarView({super.key, required this.isPageEnabled});
+  const CalendarView({super.key, required this.isPageEnabled, required this.scrollController});
   final bool isPageEnabled;
+  final ScrollController scrollController;
 
   @override
   State<StatefulWidget> createState() => _CalendarViewState();
@@ -20,6 +21,7 @@ class _CalendarViewState extends State<CalendarView> {
       width: MediaQuery.of(context).size.width - 120,
       color: widget.isPageEnabled ? Colors.blue : Colors.white,
       child: ListView.builder(
+        controller: widget.scrollController,
         itemCount: itemCnt,
         itemBuilder: (_, idx) {
           return CalendarItem(idx: idx, itemColor: colorList[idx % 2]);

--- a/lib/pages/main/calendar/calendar_view.dart
+++ b/lib/pages/main/calendar/calendar_view.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:todo_project/pages/main/calendar/calendar_item.dart';
 
 class CalendarView extends StatefulWidget {
   const CalendarView({super.key, required this.isPageEnabled});
@@ -9,12 +10,21 @@ class CalendarView extends StatefulWidget {
 }
 
 class _CalendarViewState extends State<CalendarView> {
+  final colorList = [Colors.blue, Colors.white];
+  final itemCnt = 100;
+
   @override
   Widget build(BuildContext context) {
     return Container(
       height: MediaQuery.of(context).size.height,
       width: MediaQuery.of(context).size.width - 120,
       color: widget.isPageEnabled ? Colors.blue : Colors.white,
+      child: ListView.builder(
+        itemCount: itemCnt,
+        itemBuilder: (_, idx) {
+          return CalendarItem(itemColor: colorList[idx % 2]);
+        }
+      ),
     );
   }
 }

--- a/lib/pages/main/calendar/calendar_view.dart
+++ b/lib/pages/main/calendar/calendar_view.dart
@@ -22,7 +22,7 @@ class _CalendarViewState extends State<CalendarView> {
       child: ListView.builder(
         itemCount: itemCnt,
         itemBuilder: (_, idx) {
-          return CalendarItem(itemColor: colorList[idx % 2]);
+          return CalendarItem(idx: idx, itemColor: colorList[idx % 2]);
         }
       ),
     );

--- a/lib/pages/main/main_page.dart
+++ b/lib/pages/main/main_page.dart
@@ -38,10 +38,10 @@ class _MainPageState extends State<MainPage> {
   }
 
   void _syncScroll() {
-    if (_calendarScrollController.hasClients && _todoScrollController.hasClients) {
-      if (_calendarScrollController.offset != _todoScrollController.offset) {
+    if(_calendarScrollController.hasClients && _todoScrollController.hasClients) {
+      if(isCalendarEnabled) {
         _todoScrollController.jumpTo(_calendarScrollController.offset);
-      } else if (_todoScrollController.offset != _calendarScrollController.offset) {
+      } else {
         _calendarScrollController.jumpTo(_todoScrollController.offset);
       }
     }

--- a/lib/pages/main/main_page.dart
+++ b/lib/pages/main/main_page.dart
@@ -23,22 +23,26 @@ class _MainPageState extends State<MainPage> {
     super.initState();
 
     _calendarScrollController.addListener(_syncScroll);
+    _timeScrollController.addListener(_syncScroll);
     _todoScrollController.addListener(_syncScroll);
   }
 
   @override
   void dispose() {
     _calendarScrollController.removeListener(_syncScroll);
+    _timeScrollController.removeListener(_syncScroll);
     _todoScrollController.removeListener(_syncScroll);
     _calendarScrollController.dispose();
-    _todoScrollController.dispose();
-
     _pageScrollController.dispose();
+    _timeScrollController.dispose();
+    _todoScrollController.dispose();
     super.dispose();
   }
 
   void _syncScroll() {
-    if(_calendarScrollController.hasClients && _todoScrollController.hasClients) {
+    if(_calendarScrollController.hasClients
+        && _timeScrollController.hasClients
+        && _todoScrollController.hasClients) {
       if(isCalendarEnabled) {
         _timeScrollController.jumpTo(_calendarScrollController.offset);
         _todoScrollController.jumpTo(_calendarScrollController.offset);

--- a/lib/pages/main/main_page.dart
+++ b/lib/pages/main/main_page.dart
@@ -19,6 +19,35 @@ class _MainPageState extends State<MainPage> {
   bool isCalendarEnabled = true;
 
   @override
+  void initState() {
+    super.initState();
+
+    _calendarScrollController.addListener(_syncScroll);
+    _todoScrollController.addListener(_syncScroll);
+  }
+
+  @override
+  void dispose() {
+    _calendarScrollController.removeListener(_syncScroll);
+    _todoScrollController.removeListener(_syncScroll);
+    _calendarScrollController.dispose();
+    _todoScrollController.dispose();
+
+    _pageScrollController.dispose();
+    super.dispose();
+  }
+
+  void _syncScroll() {
+    if (_calendarScrollController.hasClients && _todoScrollController.hasClients) {
+      if (_calendarScrollController.offset != _todoScrollController.offset) {
+        _todoScrollController.jumpTo(_calendarScrollController.offset);
+      } else if (_todoScrollController.offset != _calendarScrollController.offset) {
+        _calendarScrollController.jumpTo(_todoScrollController.offset);
+      }
+    }
+  }
+
+  @override
   Widget build(BuildContext context) {
     return Scaffold(
       appBar: AppBar(

--- a/lib/pages/main/main_page.dart
+++ b/lib/pages/main/main_page.dart
@@ -13,7 +13,9 @@ class MainPage extends StatefulWidget {
 }
 
 class _MainPageState extends State<MainPage> {
-  final ScrollController _scrollController = ScrollController();
+  final ScrollController _calendarScrollController = ScrollController();
+  final ScrollController _todoScrollController = ScrollController();
+  final ScrollController _pageScrollController = ScrollController();
   bool isCalendarEnabled = true;
 
   @override
@@ -25,10 +27,10 @@ class _MainPageState extends State<MainPage> {
       ),
       body: Listener(
         onPointerUp: (_) {
-          _handleScrollSnap(_scrollController.offset);
+          _handleScrollSnap(_pageScrollController.offset);
         },
         child: SingleChildScrollView(
-          controller: _scrollController,
+          controller: _pageScrollController,
           scrollDirection: Axis.horizontal,
           child: Row(
             children: [
@@ -36,14 +38,20 @@ class _MainPageState extends State<MainPage> {
                 onTap: () {
                   if(!isCalendarEnabled) _handleScrollSnap(0);
                 },
-                child: CalendarView(isPageEnabled: isCalendarEnabled)
+                child: CalendarView(
+                  isPageEnabled: isCalendarEnabled,
+                  scrollController: _calendarScrollController,
+                )
               ),
               const TimeListview(),
               GestureDetector(
                 onTap: () {
-                  if(isCalendarEnabled) _handleScrollSnap(_scrollController.position.maxScrollExtent);
+                  if(isCalendarEnabled) _handleScrollSnap(_pageScrollController.position.maxScrollExtent);
                 },
-                child: TodoView(isPageEnabled: !isCalendarEnabled)
+                child: TodoView(
+                  isPageEnabled: !isCalendarEnabled,
+                  scrollController: _todoScrollController,
+                )
               )
             ],
           ),
@@ -53,20 +61,20 @@ class _MainPageState extends State<MainPage> {
   }
 
   void _handleScrollSnap(double curScrollPosition) {
-    var maxScrollPosition = _scrollController.position.maxScrollExtent;
+    var maxScrollPosition = _pageScrollController.position.maxScrollExtent;
     var curScrollRatio = curScrollPosition / maxScrollPosition * 100;
 
     setState(() {
       if(curScrollRatio < 50) {
         isCalendarEnabled = true;
-        _scrollController.animateTo(
+        _pageScrollController.animateTo(
           0,
           duration: const Duration(milliseconds: 300),
           curve: Curves.easeOut,
         );
       } else {
         isCalendarEnabled = false;
-        _scrollController.animateTo(
+        _pageScrollController.animateTo(
           maxScrollPosition,
           duration: const Duration(milliseconds: 300),
           curve: Curves.easeOut,

--- a/lib/pages/main/main_page.dart
+++ b/lib/pages/main/main_page.dart
@@ -5,7 +5,6 @@ import 'package:todo_project/pages/main/todo/todo_view.dart';
 
 class MainPage extends StatefulWidget {
   const MainPage({super.key, required this.title});
-
   final String title;
 
   @override
@@ -14,8 +13,9 @@ class MainPage extends StatefulWidget {
 
 class _MainPageState extends State<MainPage> {
   final ScrollController _calendarScrollController = ScrollController();
-  final ScrollController _todoScrollController = ScrollController();
   final ScrollController _pageScrollController = ScrollController();
+  final ScrollController _timeScrollController = ScrollController();
+  final ScrollController _todoScrollController = ScrollController();
   bool isCalendarEnabled = true;
 
   @override
@@ -40,9 +40,11 @@ class _MainPageState extends State<MainPage> {
   void _syncScroll() {
     if(_calendarScrollController.hasClients && _todoScrollController.hasClients) {
       if(isCalendarEnabled) {
+        _timeScrollController.jumpTo(_calendarScrollController.offset);
         _todoScrollController.jumpTo(_calendarScrollController.offset);
       } else {
         _calendarScrollController.jumpTo(_todoScrollController.offset);
+        _timeScrollController.jumpTo(_todoScrollController.offset);
       }
     }
   }
@@ -72,7 +74,9 @@ class _MainPageState extends State<MainPage> {
                   scrollController: _calendarScrollController,
                 )
               ),
-              const TimeListview(),
+              TimeListview(
+                scrollController: _timeScrollController,
+              ),
               GestureDetector(
                 onTap: () {
                   if(isCalendarEnabled) _handleScrollSnap(_pageScrollController.position.maxScrollExtent);

--- a/lib/pages/main/time_listview.dart
+++ b/lib/pages/main/time_listview.dart
@@ -1,7 +1,8 @@
 import 'package:flutter/material.dart';
 
 class TimeListview extends StatefulWidget {
-  const TimeListview({super.key});
+  const TimeListview({super.key, required this.scrollController});
+  final ScrollController scrollController;
 
   @override
   State<StatefulWidget> createState() => _TimeListviewState();

--- a/lib/pages/main/time_listview.dart
+++ b/lib/pages/main/time_listview.dart
@@ -11,9 +11,21 @@ class TimeListview extends StatefulWidget {
 class _TimeListviewState extends State<TimeListview> {
   @override
   Widget build(BuildContext context) {
-    return Container(
+    return SizedBox(
       width: 60,
-      color: Colors.grey,
+      child: ListView.builder(
+        controller: widget.scrollController,
+        itemCount: 24,
+        itemBuilder: (_, idx) {
+          return SizedBox(
+            height: 20,
+            child: Text(
+              idx.toString(),
+              textAlign: TextAlign.center,
+            ),
+          );
+        }
+      )
     );
   }
 }

--- a/lib/pages/main/todo/todo_item.dart
+++ b/lib/pages/main/todo/todo_item.dart
@@ -1,8 +1,9 @@
 import 'package:flutter/material.dart';
 
 class TodoItem extends StatelessWidget {
-  const TodoItem({super.key, required this.itemColor});
+  const TodoItem({super.key, required this.itemColor, required this.idx});
   final Color itemColor;
+  final int idx;
 
   @override
   Widget build(BuildContext context) {
@@ -10,6 +11,7 @@ class TodoItem extends StatelessWidget {
       color: itemColor,
       height: 20,
       width: double.maxFinite,
+      child: Text(idx.toString()),
     );
   }
 }

--- a/lib/pages/main/todo/todo_item.dart
+++ b/lib/pages/main/todo/todo_item.dart
@@ -1,0 +1,15 @@
+import 'package:flutter/material.dart';
+
+class TodoItem extends StatelessWidget {
+  const TodoItem({super.key, required this.itemColor});
+  final Color itemColor;
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      color: itemColor,
+      height: 20,
+      width: double.maxFinite,
+    );
+  }
+}

--- a/lib/pages/main/todo/todo_view.dart
+++ b/lib/pages/main/todo/todo_view.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:todo_project/pages/main/todo/todo_item.dart';
 
 class TodoView extends StatefulWidget {
   const TodoView({super.key, required this.isPageEnabled});
@@ -9,12 +10,21 @@ class TodoView extends StatefulWidget {
 }
 
 class _TodoViewState extends State<TodoView> {
+  final colorList = [Colors.green, Colors.white];
+  final itemCnt = 100;
+
   @override
   Widget build(BuildContext context) {
     return Container(
       height: MediaQuery.of(context).size.height,
       width: MediaQuery.of(context).size.width - 120,
-      color: widget.isPageEnabled ? Colors.green : Colors.white,
+      color: widget.isPageEnabled ? Colors.blue : Colors.white,
+      child: ListView.builder(
+          itemCount: itemCnt,
+          itemBuilder: (_, idx) {
+            return TodoItem(itemColor: colorList[idx % 2]);
+          }
+      ),
     );
   }
 }

--- a/lib/pages/main/todo/todo_view.dart
+++ b/lib/pages/main/todo/todo_view.dart
@@ -2,8 +2,9 @@ import 'package:flutter/material.dart';
 import 'package:todo_project/pages/main/todo/todo_item.dart';
 
 class TodoView extends StatefulWidget {
-  const TodoView({super.key, required this.isPageEnabled});
+  const TodoView({super.key, required this.isPageEnabled, required this.scrollController});
   final bool isPageEnabled;
+  final ScrollController scrollController;
 
   @override
   State<StatefulWidget> createState() => _TodoViewState();
@@ -20,6 +21,7 @@ class _TodoViewState extends State<TodoView> {
       width: MediaQuery.of(context).size.width - 120,
       color: widget.isPageEnabled ? Colors.blue : Colors.white,
       child: ListView.builder(
+          controller: widget.scrollController,
           itemCount: itemCnt,
           itemBuilder: (_, idx) {
             return TodoItem(idx: idx, itemColor: colorList[idx % 2]);

--- a/lib/pages/main/todo/todo_view.dart
+++ b/lib/pages/main/todo/todo_view.dart
@@ -22,7 +22,7 @@ class _TodoViewState extends State<TodoView> {
       child: ListView.builder(
           itemCount: itemCnt,
           itemBuilder: (_, idx) {
-            return TodoItem(itemColor: colorList[idx % 2]);
+            return TodoItem(idx: idx, itemColor: colorList[idx % 2]);
           }
       ),
     );


### PR DESCRIPTION
## Summary
Main 페이지의 스크롤 연동을 구현하였습니다.

## Description
- Calendar, Todo 및 TimeList 각각의 스크롤은 각 위젯/뷰에서 담당하되, ScrollController를 Main에서 일괄로 관리합니다.
- 따라서 Main에서 각 스크롤 이벤트를 모니터링한 뒤, 변화값을 나머지 뷰에 전달해 스크롤을 이동시키는 방식으로 스크롤 연동을 구현하였습니다.
- 현재 무한스크롤 관련해서 별다른 패치를 수행하지 않아 TimeList의 경우에는 `0 - 24`의 스크롤이 끝나면 연동이 이루어지지 않는데, 추후 타임슬롯을 늘리는 방식을 적용하면 됩니다.
- 추가로, Android Build 과정에서 지속적으로 발생하는 NDK 버전 관련 Warning을 해결하고자 NDK 환경 버전을 조정하였습니다.

https://github.com/user-attachments/assets/ec240807-5427-413e-b6cd-81f8b57b1a73

